### PR TITLE
fix: wait until page is completely loaded

### DIFF
--- a/utils/utils.ts
+++ b/utils/utils.ts
@@ -22,7 +22,8 @@ const loadPageData = async (url: string): Promise<CheerioAPI> => {
   });
   try {
     const page = await browser.newPage();
-    await page.goto(url);
+    await page.goto(url, { waitUntil: "networkidle0" });
+    // await page.goto(url, {waitUntil: 'networkidle2'});
     data = await page.content();
     await browser.close();
     loadPageCache.set(url, cheerio.load(data));


### PR DESCRIPTION
In siti con CMS headless o comunque in generale dove componenti della pagina sono caricati successivamente le validazioni sui data attribute fallisce. 

Nelle prove fatte sia con `networkidle0` che con `networkidle2` le pagine sembrano validate correttamente, lasciato `networkidle0` che da documentazione sembrerebbe più conservativo.

https://pptr.dev/api/puppeteer.page.reload/#remarks