### PR TITLE
gestione parametro timeout per le richieste al sito

### DIFF
--- a/src/audits/municipality/bootstrapItaliaDoubleCheckAudit.ts
+++ b/src/audits/municipality/bootstrapItaliaDoubleCheckAudit.ts
@@ -5,7 +5,7 @@
 import lighthouse from "lighthouse";
 import semver from "semver";
 import { auditDictionary } from "../../storage/auditDictionary";
-import { checkCSSClassesOnPage } from "../../utils/utils";
+import { checkCSSClassesOnPage, requestTimeout } from "../../utils/utils";
 import {
   getRandomFirstLevelPagesUrl,
   getRandomSecondLevelPagesUrl,
@@ -170,7 +170,7 @@ class LoadAudit extends Audit {
             "networkidle0",
             "networkidle2",
           ],
-          timeout: 10000,
+          timeout: requestTimeout,
         });
 
         let bootstrapItaliaVariableVersion = await page.evaluate(

--- a/src/audits/municipality/fontsCheckAudit.ts
+++ b/src/audits/municipality/fontsCheckAudit.ts
@@ -9,6 +9,7 @@ import {
   getRandomThirdLevelPagesUrl,
   getPrimaryPageUrl,
 } from "../../utils/municipality/utils";
+import { requestTimeout } from "../../utils/utils";
 import puppeteer from "puppeteer";
 import { auditDictionary } from "../../storage/auditDictionary";
 import { auditScanVariables } from "../../storage/municipality/auditScanVariables";
@@ -143,7 +144,7 @@ class LoadAudit extends Audit {
             "networkidle0",
             "networkidle2",
           ],
-          timeout: 10000,
+          timeout: requestTimeout,
         });
 
         const badElements: Array<BadElement> = await page.evaluate(

--- a/src/audits/school/bootstrapItaliaDoubleCheckAudit.ts
+++ b/src/audits/school/bootstrapItaliaDoubleCheckAudit.ts
@@ -8,7 +8,7 @@ import { auditDictionary } from "../../storage/auditDictionary";
 
 const Audit = lighthouse.Audit;
 
-import { checkCSSClassesOnPage } from "../../utils/utils";
+import { checkCSSClassesOnPage, requestTimeout } from "../../utils/utils";
 import {
   getRandomFirstLevelPagesUrl,
   getRandomSecondLevelPagesUrl,
@@ -147,7 +147,7 @@ class LoadAudit extends Audit {
             "networkidle0",
             "networkidle2",
           ],
-          timeout: 10000,
+          timeout: requestTimeout,
         });
 
         let bootstrapItaliaVariableVersion = await page.evaluate(

--- a/src/audits/school/controlledVocabulariesAudit.ts
+++ b/src/audits/school/controlledVocabulariesAudit.ts
@@ -7,6 +7,7 @@ import { schoolModelVocabulary } from "../../storage/school/controlledVocabulary
 import {
   getPageElementDataAttribute,
   areAllElementsInVocabulary,
+  requestTimeout,
 } from "../../utils/utils";
 import puppeteer from "puppeteer";
 import * as cheerio from "cheerio";
@@ -120,7 +121,7 @@ async function getArgumentsElements(url: string): Promise<string[]> {
     const page = await browser.newPage();
     await page.goto(url, {
       waitUntil: ["load", "domcontentloaded", "networkidle0", "networkidle2"],
-      timeout: 10000,
+      timeout: requestTimeout,
     });
 
     await page.waitForSelector('[data-element="search-modal-button"]', {

--- a/src/audits/school/fontsCheckAudit.ts
+++ b/src/audits/school/fontsCheckAudit.ts
@@ -8,6 +8,7 @@ import {
   getRandomSecondLevelPagesUrl,
   getRandomServicesUrl,
 } from "../../utils/school/utils";
+import { requestTimeout } from "../../utils/utils";
 import puppeteer from "puppeteer";
 import { auditDictionary } from "../../storage/auditDictionary";
 import { auditScanVariables } from "../../storage/school/auditScanVariables";
@@ -131,7 +132,7 @@ class LoadAudit extends Audit {
             "networkidle0",
             "networkidle2",
           ],
-          timeout: 10000,
+          timeout: requestTimeout,
         });
 
         const badElements: Array<BadElement> = await page.evaluate(

--- a/src/controller/launchLighthouse.ts
+++ b/src/controller/launchLighthouse.ts
@@ -32,9 +32,11 @@ const run = async (
   destination: string,
   reportName: string,
   view = false,
-  accuracy = "suggested"
+  accuracy = "suggested",
+  requestTimeout = 10000
 ) => {
   process.env["accuracy"] = accuracy;
+  process.env["requestTimeout"] = requestTimeout.toString();
   //L'oggetto chrome non è incluso nel try-catch in modo tale che la sua istanza venga killata anche in caso di eccezione lanciata da altri processi
   const browser = await puppeteer.launch({
     args: ["--no-sandbox"],

--- a/src/index.ts
+++ b/src/index.ts
@@ -50,6 +50,13 @@ const parser = yargs(hideBin(process.argv))
     demandOption: true,
     default: "suggested",
     choices: ["min", "suggested", "high", "all"],
+  })
+  .option("timeout", {
+    describe:
+      "Request timeout in milliseconds. If the request takes longer than this value, the request will be aborted",
+    type: "number",
+    demandOption: false,
+    default: 10000,
   });
 
 try {
@@ -70,7 +77,8 @@ try {
     args.destination,
     args.report,
     "view" in args,
-    args.accuracy
+    args.accuracy,
+    args.timeout
   );
 
   console.log("[INFO] Status result:", result.status);

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -10,6 +10,7 @@ import NodeCache from "node-cache";
 import { MenuItem } from "../types/menuItem";
 
 const loadPageCache = new NodeCache();
+const requestTimeout = parseInt(process.env["requestTimeout"] ?? "10000");
 
 const loadPageData = async (url: string): Promise<CheerioAPI> => {
   let data = "";
@@ -24,7 +25,7 @@ const loadPageData = async (url: string): Promise<CheerioAPI> => {
     const page = await browser.newPage();
     await page.goto(url, {
       waitUntil: ["load", "domcontentloaded", "networkidle0", "networkidle2"],
-      timeout: 10000,
+      timeout: requestTimeout,
     });
     // await page.goto(url, {waitUntil: 'networkidle2'});
     data = await page.content();
@@ -32,6 +33,7 @@ const loadPageData = async (url: string): Promise<CheerioAPI> => {
     loadPageCache.set(url, cheerio.load(data));
     return cheerio.load(data);
   } catch (ex) {
+    process.env["DEBUG"] && console.log(ex);
     await browser.close();
     loadPageCache.set(url, cheerio.load(data));
     return cheerio.load(data);
@@ -361,4 +363,5 @@ export {
   checkBreadcrumb,
   cmsThemeRx,
   getAllPageHTML,
+  requestTimeout,
 };


### PR DESCRIPTION
Per aiutare a gestire eccezioni come quelle segnalate in #205 e #227 abbiamo aggiunto un parametro opzionale "--timeout". Il default, se il parametro non è usato, rimane l'attuale di 10s. 

Se capisco il problema per chi fa sviluppo e verifica dei propri siti è non riuscire a fare test consistenti perchè i tempi generali di risposta e caricamento delle pagine con il validatore possono dipendere non solo dalle prestazioni di un sito in produzione, ma dalle prestazioni di un sito di sviluppo/staging e, probabilmente, anche da prestazioni del computer dove viene fatto girare il validatore. 

Usando il parametro è possibile in fase di test fare verifiche bypassando questo tipo di problemi. 