### PR TITLE
school serviziAudit, fix breacrumbs parsing

### DIFF
--- a/src/audits/school/serviziAudit.ts
+++ b/src/audits/school/serviziAudit.ts
@@ -200,9 +200,9 @@ class LoadAudit extends Audit {
       );
       breadcrumbElements = breadcrumbElements.map((x) =>
         x
+          .replaceAll(/[^a-zA-Z0-9 ]/g, "")
           .trim()
           .toLowerCase()
-          .replaceAll(/[^a-zA-Z0-9 ]/g, "")
       );
 
       if (!checkBreadcrumb(breadcrumbElements)) {


### PR DESCRIPTION
R.SC.1.2 - il parsing del breadcrumb non è corretto (vedi issue [#335](https://github.com/italia/pa-website-validator/issues/355))