### PR TITLE
school controlledVocabulariesAudit, fix topics retrieval for SPA

### DIFF
--- a/src/audits/school/controlledVocabulariesAudit.ts
+++ b/src/audits/school/controlledVocabulariesAudit.ts
@@ -160,7 +160,7 @@ async function getArgumentsElements(url: string): Promise<string[]> {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     await button?.evaluate((b: any) => b.click());
 
-    await page.waitForNavigation();
+    await page.waitForSelector('[data-element="all-topics"]');
 
     const $ = cheerio.load(await page.content());
     if ($.length <= 0) {


### PR DESCRIPTION
R.SC.1.1 - Il recupero della lista di argomenti può fallire per le SPA (vedi issue [#359](https://github.com/italia/pa-website-validator/issues/359))