### PR TITLE
fix(R.SC.2.2): accept `'` character in legal notes

### DIFF
--- a/src/audits/school/licenseAndAttributionAudit.ts
+++ b/src/audits/school/licenseAndAttributionAudit.ts
@@ -115,11 +115,15 @@ class LoadAudit extends Audit {
       const bodyElements = $(bodyDataElement);
       let textBody = "";
       for (const bodyElement of bodyElements) {
-        textBody +=
-          $(bodyElement)?.text().trim().toLowerCase().replaceAll(/\s+/g, " ") ??
-          "";
+        textBody += $(bodyElement).text();
         textBody += " ";
       }
+      textBody = textBody
+        .trim()
+        .toLowerCase()
+        .replaceAll(/\s+/g, " ")
+        .replaceAll("'", "’");
+
       if (textBody === legalNotes.body.text.toLowerCase()) {
         items[0].page_contains_correct_text = "Sì";
       }


### PR DESCRIPTION
Adapt to changes in [8ffdfa9](https://github.com/italia/pa-website-validator/commit/8ffdfa9d7ef29cd93248aadf8ee5a7d3b32a6744).