### PR TITLE
chore: update nix flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1710889954,
-        "narHash": "sha256-Pr6F5Pmd7JnNEMHHmspZ0qVqIBVxyZ13ik1pJtm2QXk=",
+        "lastModified": 1717112898,
+        "narHash": "sha256-7R2ZvOnvd9h8fDd65p0JnB7wXfUvreox3xFdYWd1BnY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "7872526e9c5332274ea5932a0c3270d6e4724f3b",
+        "rev": "6132b0f6e344ce2fe34fc051b72fb46e34f668e0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/7872526e9c5332274ea5932a0c3270d6e4724f3b' (2024-03-19)
  → 'github:NixOS/nixpkgs/6132b0f6e344ce2fe34fc051b72fb46e34f668e0' (2024-05-30)